### PR TITLE
Remove console spam for bun users

### DIFF
--- a/packages/astro/src/cli/info/index.ts
+++ b/packages/astro/src/cli/info/index.ts
@@ -75,13 +75,7 @@ export async function getInfoOutput({
 	for (const [label, value] of rows) {
 		output += printRow(label, value, print);
 	}
-
-	if (packageManager === 'bun') {
-		console.warn(
-			'Bun is not officially supported by Astro. Unable to retreive certain version information.',
-		);
-	}
-
+	
 	return output.trim();
 }
 


### PR DESCRIPTION
## Changes

previously, Bun users were seeing this when they ran `astro dev`, `astro build`, etc.

<img width="1018" height="731" alt="image" src="https://github.com/user-attachments/assets/36a14f73-165e-4627-bbb2-be8c814eb469" />

This was introduced in https://github.com/withastro/astro/pull/14300 not realizing that the helper function `getInfoOutput()` was called outside of `astro info` during normal render, for debugging purposes.

This PR removes that warning for now, since we shouldn't be printing inside of a helper utility like that. We could add it back in the future, but I also don't think it's communicating the correct message about our Bun support (tldr: we support Node, and Bun is Node compatible, so Astro should be expected to work correctly in Bun. if it does not, that's bun's problem to solve, but that is different from "Bun is not supported").

## Testing

Not tested, just removed a console log.

## Docs

Not needed.